### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java-ci-maven.yml
+++ b/.github/workflows/java-ci-maven.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/sadramesbah/load-balancer-simulator/security/code-scanning/1](https://github.com/sadramesbah/load-balancer-simulator/security/code-scanning/1)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.  
Best fix: set workflow-level permissions so all jobs inherit it unless overridden. For this workflow, `contents: read` is sufficient for `actions/checkout` and Maven build steps.

Edit `.github/workflows/java-ci-maven.yml` by inserting:

```yml
permissions:
  contents: read
```

right after the `on:` trigger section (before `jobs:`), preserving existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
