### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   create_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sadramesbah/load-balancer-simulator/security/code-scanning/2](https://github.com/sadramesbah/load-balancer-simulator/security/code-scanning/2)

Add an explicit `permissions` block to the workflow (or job) to enforce least privilege while preserving current behavior.

Best fix here: add workflow-level permissions directly under `on:` (before `jobs:`), since there is only one job shown and it needs the same token scope. For creating a GitHub release via `actions/create-release`, the minimum practical permission is:

- `contents: write`

This both resolves the CodeQL finding and keeps release creation working. No imports, methods, or dependencies are needed—just YAML changes in `.github/workflows/create-release.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
